### PR TITLE
Upgrade to ES 6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project is split into two sub projects:
 
 
 ## Versions
-Two first digits of SEL version match Elasticsearch version and then it's the inner SEL version, eg 5.5.1 works with ES 5.5, v1 of SEL for this version of ES
+Two first digits of SEL version match Elasticsearch version and then it's the inner SEL version, eg 6.8.1 works with ES 6.8, v1 of SEL for this version of ES
 
 
 ## Full documentation
@@ -16,7 +16,7 @@ Two first digits of SEL version match Elasticsearch version and then it's the in
 
 
 ## Compagny
-SEL was initially developed for Heuritech in 2015 and used by everybody inside the compagny tech and no-tech people since that time to explore internal data, generate reports and analysis.
+SEL was initially developed for Heuritech in 2016 and used by everybody inside the compagny tech and no-tech people since that time to explore internal data, generate reports and analysis.
 
 
 ## Quickstart
@@ -25,7 +25,7 @@ Be aware it will request ES schema at any query generation.
 
 #### Add as dependency
 ```
-sel @ git+https://github.com/ArnaudParant/sel.git@v5.5.1
+sel @ git+https://github.com/ArnaudParant/sel.git@v6.8.1
 ```
 
 ### SEL as ES interface
@@ -69,3 +69,15 @@ See [SEL Server](https://github.com/ArnaudParant/sel_server) for API usage
  - **install-sphinx** - Install Sphinx and dependencies to generate documentation.  
  - **doc** - Generate the documentation in `docs/build/html/`  
  - **clean** - Clean all `__pycache__`
+
+
+## Known issue
+
+```
+[1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
+```
+
+Execute the following command
+```
+sysctl -w vm.max_map_count=262144
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'SEL 5.5.1'
+project = 'SEL 6.8.1'
 copyright = '2024, Arnaud Parant'
 author = 'Arnaud Parant'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Simple Elastic Language's documentation v5.5.1 !
+Welcome to Simple Elastic Language's documentation v6.8.1 !
 ===========================================================
 
 .. toctree::

--- a/docs/source/query_guide.md
+++ b/docs/source/query_guide.md
@@ -55,7 +55,7 @@ Used for paging, it does not impact aggregations, such:
 **Extended**
 
 Allowed keys: `_source`, `fields`, `script_fields`, `fielddata_fields`, `explain`, `highlight`, `rescore`, `version`, `indices_boost`, `min_score`.  
-See [ES Search request body](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/search-request-body.html)
+See [ES Search request body](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-body.html)
 
 **Examples**
 
@@ -124,7 +124,7 @@ label.entity = 'bg:model'
 
 #### Query String
 
-Query string use [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-query-string-query.html)
+Query string use [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
 
 ```
 label ~ "*pant*"
@@ -133,7 +133,7 @@ label ~ "*pant*"
 
 #### Not match query string
 
-Query string use [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-query-string-query.html)
+Query string use [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
 
 ```
 label !~ "*pant*"
@@ -293,7 +293,7 @@ not 2018 <= date <= 2019
 
 ### Query string
 
-Query string will match the `DefaultQueryStringFieldPath` (from `conf.ini`) with [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-query-string-query.html).  
+Query string will match the `DefaultQueryStringFieldPath` (from `conf.ini`) with [ES query string format](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html).  
 
 ```
 "foam cage"
@@ -930,7 +930,7 @@ Advance interval exists, such as:
 3h  # 3 hours
 ```
 
-See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/common-options.html#time-units)
+See [Time units](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/common-options.html#time-units)
 
 ### Sub aggregations
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SEL
-version = 5.5.1
+version = 6.8.1
 description = Simple Elastic Language
 long_description = file: README.md
 author = Arnaud Parant
@@ -18,7 +18,7 @@ setup_requires =
     pip >= 20.1
 
 install_requires =
-    elasticsearch==5.5.3
+    elasticsearch==6.8.2
     pyPEG2==2.15.2
     python-dateutil==2.6
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - overlay
 
   elasticsearch:
-    image: elasticsearch:5.5
+    image: elasticsearch:6.8.0
     command: elasticsearch
     healthcheck:
       test: curl -s http://localhost:9200 >/dev/null || exit 1


### PR DESCRIPTION
Upgrade to ES 6.x

No changes into the SEL query system.

See the official [Upgrade to Elasticsearch 6.x](https://www.elastic.co/guide/en/cloud/current/ec-upgrading-v6.html#ec-upgrading-v6)